### PR TITLE
Drop yarn as dependency on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "homepage": "https://github.com/trivago/prettier-plugin-sort-imports#readme",
   "scripts": {
-    "prepare": "yarn run compile",
+    "prepare": "npm run compile",
     "compile": "tsc",
     "preexample": "yarn run compile",
     "example": "prettier --config ./examples/.prettierrc --plugin lib/src/index.js",


### PR DESCRIPTION
I ran into this same thing with my fork.

This change will necessitate a new tag in our FE repo.


![CleanShot 2024-12-30 at 15 15 24@2x](https://github.com/user-attachments/assets/34c15bb2-6d3e-40f3-9772-554b9d1acb83)

